### PR TITLE
ミノの落下と衝突判定

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -94,6 +94,9 @@ impl App {
             position: Point { y: 0, x: 0 },
         }
     }
+    pub fn reset_position(&mut self) {
+        self.position = Point { y: 0, x: 0 };
+    }
     fn is_out_of_range(&self, py: i32, px: i32) -> bool {
         if py < 0 || py >= 20 || px < 0 || px >= 10 {
             return true;
@@ -116,19 +119,46 @@ impl App {
         }
         return false;
     }
+    fn move_mino(&mut self, diff: Point) -> bool {
+        let np = Point {
+            y: self.position.y + diff.y,
+            x: self.position.x + diff.x,
+        };
+        for i in 0..self.mino.block.shape.len() {
+            let [y, x] = self.mino.block.shape[i];
+            let ny = y + np.y;
+            let nx = x + np.x;
+            if self.is_out_of_range(ny, nx) {
+                return false;
+            }
+        }
+        // 削除
+        for i in 0..self.mino.block.shape.len() {
+            let [y, x] = self.mino.block.shape[i];
+            let ny = y + self.position.y;
+            let nx = x + self.position.x;
+            self.board[ny as usize][nx as usize] = 0;
+        }
+        self.position = np;
+        // 移動
+        for i in 0..self.mino.block.shape.len() {
+            let [y, x] = self.mino.block.shape[i];
+            let ny = y + self.position.y;
+            let nx = x + self.position.x;
+            self.board[ny as usize][nx as usize] = 1;
+        }
+        return true;
+    }
     pub fn fall(&mut self) -> bool {
         if !self.mino.is_falling {
             return false;
         }
-        if self.is_conflict(&self.mino) {
-            return false;
-        }
-        // ミノを1つ下に落とす
-        return true;
+        return self.move_mino(Point { y: 1, x: 0 });
     }
     // create new block at the top of the board
     pub fn spawn(&mut self) -> bool {
         let mino = Mino::new();
+        self.reset_position();
         if self.is_conflict(&mino) {
             return false;
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -58,15 +58,19 @@ impl Shape {
 }
 
 pub struct Mino {
-    pub shape: Shape,           // shape of the tetromino
-    pub board: [[i32; 10]; 20], // 20x10 board
+    pub is_falling: bool,
+    pub shape: Shape,       // shape of the tetromino
+    pub position: [i32; 2], // position of the tetromino
 }
 
 impl Mino {
     pub fn new() -> Self {
         Mino {
+            is_falling: false,
             shape: Shape::new(),
-            board: [[0; 10]; 20],
+            position: [0, 0],
+        }
+    }
         }
     }
 }
@@ -75,6 +79,7 @@ pub struct App {
     pub score: u64,
     pub should_quit: bool,
     pub mino: Mino,
+    pub board: [[i32; 10]; 20], // 20x10 board
 }
 
 impl App {
@@ -83,6 +88,18 @@ impl App {
             score: 0,
             should_quit: false,
             mino: Mino::new(),
+            board: [[0; 10]; 20],
         }
+    }
+    // create new block at the top of the board
+    pub fn spawn(&mut self) -> bool {
+        let mino = Mino::new();
+        let shape = mino.shape.shape;
+        for i in 0..shape.len() {
+            let [y, x] = shape[i];
+            self.board[y as usize][x as usize] = 1;
+        }
+        self.mino = mino;
+        return true;
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -59,26 +59,28 @@ impl Shape {
 
 pub struct Mino {
     pub is_falling: bool,
-    pub shape: Shape,       // shape of the tetromino
-    pub position: [i32; 2], // position of the tetromino
+    pub block: Shape, // shape of the tetromino
 }
 
 impl Mino {
     pub fn new() -> Self {
         Mino {
             is_falling: false,
-            shape: Shape::new(),
-            position: [0, 0],
+            block: Shape::new(),
         }
     }
-        }
-    }
+}
+
+pub struct Point {
+    pub y: i32,
+    pub x: i32,
 }
 
 pub struct App {
     pub score: u64,
     pub should_quit: bool,
     pub mino: Mino,
+    pub position: Point,        // left corner of the tetromino
     pub board: [[i32; 10]; 20], // 20x10 board
 }
 
@@ -89,17 +91,53 @@ impl App {
             should_quit: false,
             mino: Mino::new(),
             board: [[0; 10]; 20],
+            position: Point { y: 0, x: 0 },
         }
+    }
+    fn is_out_of_range(&self, py: i32, px: i32) -> bool {
+        if py < 0 || py >= 20 || px < 0 || px >= 10 {
+            return true;
+        }
+        return false;
+    }
+    fn is_conflict(&self, mino: &Mino) -> bool {
+        let shape = &mino.block.shape;
+        let position = &self.position;
+        for i in 0..shape.len() {
+            let [y, x] = shape[i];
+            let cy = y + position.y;
+            let cx = x + position.x;
+            if self.is_out_of_range(cy, cx) {
+                return true;
+            }
+            if self.board[cy as usize][cx as usize] == 1 {
+                return true;
+            }
+        }
+        return false;
+    }
+    pub fn fall(&mut self) -> bool {
+        if !self.mino.is_falling {
+            return false;
+        }
+        if self.is_conflict(&self.mino) {
+            return false;
+        }
+        // ミノを1つ下に落とす
+        return true;
     }
     // create new block at the top of the board
     pub fn spawn(&mut self) -> bool {
         let mino = Mino::new();
-        let shape = mino.shape.shape;
+        if self.is_conflict(&mino) {
+            return false;
+        }
+        self.mino = mino;
+        let shape = self.mino.block.shape;
         for i in 0..shape.len() {
             let [y, x] = shape[i];
             self.board[y as usize][x as usize] = 1;
         }
-        self.mino = mino;
         return true;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,13 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 fn run_app<B: Backend>(app: &mut App, terminal: &mut Terminal<B>) -> io::Result<bool> {
     loop {
+        if !app.mino.is_falling {
+            app.mino.is_falling = true;
+            if !app.spawn() {
+                app.should_quit = true;
+            }
+        }
+
         terminal.draw(|f| ui::ui(f, app))?;
 
         if let Event::Key(key) = event::read()? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,15 +58,18 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 fn run_app<B: Backend>(app: &mut App, terminal: &mut Terminal<B>) -> io::Result<bool> {
     loop {
-        terminal.draw(|f| ui::ui(f, app))?;
-
-        // 新しいミノの生成
+        if !app.fall() {
+            app.mino.is_falling = false;
+        }
+        // 新規作成
         if !app.mino.is_falling {
-            app.mino.is_falling = true;
             if !app.spawn() {
                 app.should_quit = true;
             }
+            app.mino.is_falling = true;
         }
+
+        terminal.draw(|f| ui::ui(f, app))?;
 
         // TODO: move to the other thread
         if let Event::Key(key) = event::read()? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,11 +58,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 fn run_app<B: Backend>(app: &mut App, terminal: &mut Terminal<B>) -> io::Result<bool> {
     loop {
+        // 落下
         if !app.fall() {
             app.mino.is_falling = false;
         }
-        // 新規作成
         if !app.mino.is_falling {
+            // 新規作成
             if !app.spawn() {
                 app.should_quit = true;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 fn run_app<B: Backend>(app: &mut App, terminal: &mut Terminal<B>) -> io::Result<bool> {
     loop {
+        terminal.draw(|f| ui::ui(f, app))?;
+
+        // 新しいミノの生成
         if !app.mino.is_falling {
             app.mino.is_falling = true;
             if !app.spawn() {
@@ -65,8 +68,7 @@ fn run_app<B: Backend>(app: &mut App, terminal: &mut Terminal<B>) -> io::Result<
             }
         }
 
-        terminal.draw(|f| ui::ui(f, app))?;
-
+        // TODO: move to the other thread
         if let Event::Key(key) = event::read()? {
             if key.kind == event::KeyEventKind::Release {
                 continue;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,4 @@
-use crate::app::App;
+use crate::app::{App, Mino};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -7,6 +7,8 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
     Frame,
 };
+
+const CELL: char = '□';
 
 fn render_header(f: &mut Frame, app: &App, chunk: Rect) {
     let header_area = Layout::default()
@@ -36,6 +38,28 @@ fn render_header(f: &mut Frame, app: &App, chunk: Rect) {
     f.render_widget(score_block, header_area[1]);
 }
 
+fn render_body(f: &mut Frame, app: &App, chunk: Rect) {
+    let body_area = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(10)])
+        .split(chunk);
+    let mut lines: Vec<Line> = Vec::new();
+    for (_, row) in app.mino.board.iter().enumerate() {
+        let mut rs = String::new();
+        for (_, cell) in row.iter().enumerate() {
+            if *cell == 0 {
+                rs.push(' ');
+            } else {
+                rs.push(CELL);
+            }
+        }
+        lines.push(Line::from(rs));
+    }
+    let text = Text::from(lines);
+    let block = Paragraph::new(text).block(Block::bordered());
+    f.render_widget(block, body_area[0]);
+}
+
 pub fn ui(f: &mut Frame, app: &App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -43,4 +67,5 @@ pub fn ui(f: &mut Frame, app: &App) {
         .split(f.size());
 
     render_header(f, app, chunks[0]);
+    render_body(f, app, chunks[1]);
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,4 @@
-use crate::app::{App, Mino};
+use crate::app::App;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -44,7 +44,7 @@ fn render_body(f: &mut Frame, app: &App, chunk: Rect) {
         .constraints([Constraint::Length(10)])
         .split(chunk);
     let mut lines: Vec<Line> = Vec::new();
-    for (_, row) in app.mino.board.iter().enumerate() {
+    for (_, row) in app.board.iter().enumerate() {
         let mut rs = String::new();
         for (_, cell) in row.iter().enumerate() {
             if *cell == 0 {


### PR DESCRIPTION
# 変更内容
- ミノの落下を実装
- ミノ同士の衝突・枠との衝突を検出
- 大まかなリファクタリング
# 動作確認
適当なキーを押し続けて、ミノが縦積みになって最終的に積めない状態になったときにアプリは終了する。